### PR TITLE
feat(arena): #25 memory arena

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ Module.symvers
 Mkfile.old
 dkms.conf
 
+*.vim

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ OBJDIR = obj
 SOURCES = \
 		  main.c	\
 		  repl.c	\
-		  signals.c
+		  signals.c \
+		  arena.c \
 
 OBJECTS = $(SOURCES:%.c=$(OBJDIR)/%.o)
 SRCFILES = $(addprefix $(SRCDIR)/, $(SOURCES))

--- a/include/arena.h
+++ b/include/arena.h
@@ -1,0 +1,34 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   arena.h                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: trupham <trupham@student.hive.fi>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/08/03 11:28:11 by trupham           #+#    #+#             */
+/*   Updated: 2025/08/03 11:54:22 by trupham          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef ARENA_H
+#define ARENA_H
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifndef ARENA_CAP
+#define ARENA_CAP 1024
+#endif // !ARENA_CAP
+typedef struct s_arena
+{
+	uint64_t capacity;
+	uint64_t cursor;
+	uintptr_t *data;
+	struct s_arena *next;
+} t_arena;
+
+t_arena *arena_init(uint64_t capacity);
+void *arena_alloc(t_arena *arena, uint64_t size);
+void arena_free(t_arena *arena);
+t_arena *get_static_arena();
+
+#endif // !ARENA_H

--- a/include/arena.h
+++ b/include/arena.h
@@ -28,6 +28,7 @@ typedef struct s_arena
 
 t_arena *arena_init(uint64_t capacity);
 void *arena_alloc(t_arena *arena, uint64_t size);
+void *s_malloc(uint64_t size);
 void arena_free(t_arena *arena);
 t_arena *get_static_arena();
 

--- a/src/arena.c
+++ b/src/arena.c
@@ -13,6 +13,7 @@
 #include "arena.h"
 #include "libft.h"
 #include <stdio.h>
+#include <stdlib.h>
 
 /*@brief: initialize the memory arena with max size of capacity
 * @return: pointer to the arena
@@ -75,6 +76,20 @@ void arena_free(t_arena *arena)
 		free(arena);
 		arena = next;
 	}
+}
+
+void *s_malloc(uint64_t size)
+{
+	void *buf;
+
+	buf = arena_alloc(get_static_arena(), size);
+	if (!buf)
+	{
+		arena_free(get_static_arena());
+		ft_putendl_fd("failed to allocate memory arena", 2);
+		exit(EXIT_FAILURE);
+	}
+	return buf;
 }
 
 t_arena *get_static_arena()

--- a/src/arena.c
+++ b/src/arena.c
@@ -1,0 +1,91 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   arena.c                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: trupham <trupham@student.hive.fi>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/08/03 11:54:34 by trupham           #+#    #+#             */
+/*   Updated: 2025/08/03 11:57:26 by trupham          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "arena.h"
+#include "libft.h"
+#include <stdio.h>
+
+/*@brief: initialize the memory arena with max size of capacity
+* @return: pointer to the arena
+*/
+t_arena *arena_init(uint64_t capacity)
+{
+	t_arena *arena;
+	
+	arena = malloc(sizeof(t_arena));
+	if (!arena)
+		return NULL;
+	arena->data = ft_calloc(capacity, sizeof(char));
+	if (!arena->data)
+	{
+		free(arena);
+		return NULL;
+	}
+	arena->cursor = 0;
+	arena->capacity = capacity;
+	arena->next = NULL;
+	return arena;
+}
+
+/* @brief: allocate memory in the arena. if there is not enough space, move to
+ * the next avaiable arena in the linked list
+ * @params: the head arena, the size to be allocated
+ * @return: pointer to the buffer in the arena
+*/
+void *arena_alloc(t_arena *arena, uint64_t size)
+{
+	void *buf;
+	t_arena *next;
+
+	next = NULL;
+	while (arena->cursor + size > arena->capacity)
+	{
+		if (arena->next == NULL)
+		{
+			next = arena_init(arena->capacity);
+			if (!next)
+				return NULL;
+			arena->next = next;
+		}
+		arena = arena->next;
+	}
+	buf = &arena->data[arena->cursor];
+	arena->cursor += size;
+	return buf;
+}
+
+void arena_free(t_arena *arena)
+{
+	t_arena *next;
+
+	next = NULL;
+	while (arena)
+	{
+		next = arena->next;
+		free(arena->data);
+		free(arena);
+		arena = next;
+	}
+}
+
+t_arena *get_static_arena()
+{
+	static t_arena *arena;
+
+	if (!arena)
+	{
+		arena = arena_init(ARENA_CAP);
+		if (!arena)
+			return NULL;
+	}
+	return arena;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -6,10 +6,11 @@
 /*   By: jyniemit <jyniemit@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/29 14:50:29 by jyniemit          #+#    #+#             */
-/*   Updated: 2025/07/29 15:12:40 by jyniemit         ###   ########.fr       */
+/*   Updated: 2025/08/07 11:38:35 by trupham          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include "libft.h"
 #include "minishell.h"
 
 int	main(int ac, char **av)

--- a/test/test_arena.c
+++ b/test/test_arena.c
@@ -30,16 +30,16 @@ int main()
 {
 	t_arena *arena = get_static_arena();
 
-	char *buf = arena_alloc(arena, 12);
+	char *buf = s_malloc(12);
 	ft_strlcpy(buf, "hello world", 12);
 	print_arena();
-	t_list *list = arena_alloc(arena, sizeof(t_list));
+	t_list *list = s_malloc(sizeof(t_list));
 	(void)list;
 	print_arena();
-	char *bur1 = arena_alloc(arena, 1000);
+	char *bur1 = s_malloc(1000);
 	(void)bur1;
 	print_arena();
-	char *bur2 = arena_alloc(arena, 14);
+	char *bur2 = s_malloc(14);
 	(void)bur2;
 	print_arena();
 	arena_free(arena);

--- a/test/test_arena.c
+++ b/test/test_arena.c
@@ -1,0 +1,46 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   test_arena.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: trupham <trupham@student.hive.fi>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/08/07 11:38:02 by trupham           #+#    #+#             */
+/*   Updated: 2025/08/07 11:38:35 by trupham          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+#include "arena.h"
+
+void print_arena()
+{
+	t_arena *arena = get_static_arena();
+
+	int count = 0;
+	while (arena)
+	{
+		ft_printf("[debug] arena cursor %d: %d\n", count, arena->cursor);
+		count++;
+		arena = arena->next;
+	}
+}
+
+int main()
+{
+	t_arena *arena = get_static_arena();
+
+	char *buf = arena_alloc(arena, 12);
+	ft_strlcpy(buf, "hello world", 12);
+	print_arena();
+	t_list *list = arena_alloc(arena, sizeof(t_list));
+	(void)list;
+	print_arena();
+	char *bur1 = arena_alloc(arena, 1000);
+	(void)bur1;
+	print_arena();
+	char *bur2 = arena_alloc(arena, 14);
+	(void)bur2;
+	print_arena();
+	arena_free(arena);
+}


### PR DESCRIPTION
>[!NOTE]
>The memory arena capacity is something we need to determine the optimal number. You mentioned something about L3 cache. I've added ARENA_CAP macro initially set at 1024 in the arena.h

In commit `853034b` I've added `get_static_arena` function which we could call from anywhere to get the static arena. Not sure if this is a good way to do it. I've just figured rather than keep passing arena pointer to every function that use it, we could just call get_static_arena inside any function that needs to allocate memory. 